### PR TITLE
Fix #5 Prevent MigrationAutoDetector removes the user unique email constraint

### DIFF
--- a/src/unique_user_email/apps.py
+++ b/src/unique_user_email/apps.py
@@ -23,4 +23,4 @@ class UniqueUserEmailConfig(AppConfig):
         ]
         User._meta.constraints = User.Meta.constraints
         # ... as long as original_attrs is not updated.
-        # User._meta.original_attrs["constraints"] = User.Meta.constraints
+        User._meta.original_attrs["constraints"] = User.Meta.constraints

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,6 +6,7 @@ from django.db import IntegrityError
 from django.test import TestCase
 from unique_user_email.backend import EmailBackend
 from unique_user_email.forms import AuthenticationForm
+from django.db.models.constraints import UniqueConstraint
 
 
 class UniqueEmailTestCase(TestCase):
@@ -55,6 +56,13 @@ class UniqueEmailTestCase(TestCase):
         ):
             user2.save()
 
+    def test_user_constraints(self):
+        self.assertIsInstance(User._meta.constraints[0], UniqueConstraint)
+        self.assertEqual("unique_user_email", User._meta.constraints[0].name)
+        self.assertEqual(
+            "unique_user_email",
+            User._meta.original_attrs.get("constraints")[0].name
+        )
 
 class EmailBackendTests(TestCase):
     def test_none_for_username_logins(self):


### PR DESCRIPTION
Prevent MigrationAutoDetector removes the user unique email constraint.

After various tests and checks, it seems to me that the control on the presence of migration is a bit redundant and, indeed, could create other problems. So, I limited myself to adding a test and uncommenting the already existing line that acts on `original_attrs["constraint"]` without introducing the hypothesized control. Am I missing something?
Because it should be enough that "unique_user_email" is in the `INSTALLED_APPS` and avoid checking the presence of migrations.