### PR TITLE
Remove comment for self.request in forms.py

### DIFF
--- a/src/unique_user_email/forms.py
+++ b/src/unique_user_email/forms.py
@@ -21,7 +21,7 @@ class AuthenticationForm(forms.Form):
     )
 
     def __init__(self, request=None, *args, **kwargs):
-        self.request = request  # ???: Do we need this?
+        self.request = request
         self.user_cache = None
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
If you remove the self.request = request, you get the error 'AuthenticationForm' object has no attribute 'request' so this is needed.